### PR TITLE
ci(renovate): switch automerge from branch to PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,12 +24,12 @@
       "commitMessageTopic": "{{depName}} action"
     },
     {
-      "description": "Automerge non-major mise updates",
+      "description": "Automerge non-major mise updates via PR",
       "matchManagers": ["mise"],
       "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["mise"],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "pr"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
## Summary

Fix Renovate automerge configuration to use PR-based automerge instead of branch automerge, ensuring all updates go through pull requests and respect branch protection rules.

## Problem

PR #4 showed Renovate attempting branch automerge, which failed due to branch protection requiring PRs:
> Branch automerge failure: This PR was configured for branch automerge. However, this is not possible, so it has been raised as a PR instead.

The mise package rule was configured with `automergeType: "branch"`, which attempts to push directly to main without creating a PR, bypassing branch protection.

## Changes

- Changed mise package rule from `automergeType: "branch"` to `automergeType: "pr"`
- All automerge presets (`:automergeDigest`, `:automergeLinters`, `:automergeTesters`, `:automergeMinor`) already default to PR-based automerge

## Behavior After Fix

**All Renovate automerge updates:**
1. Create a pull request
2. Wait for CI checks to pass
3. Auto-merge the PR (respects branch protection)
4. Provides proper audit trail and notification

## Testing

- Configuration validated
- All CI checks passing
- Next Renovate run will use PR-based automerge

> Changelog: skip