### PR TITLE
fix(fish): add existence checks before sourcing

### DIFF
--- a/chezmoi/private_dot_config/fish/conf.d/omf.fish
+++ b/chezmoi/private_dot_config/fish/conf.d/omf.fish
@@ -4,4 +4,4 @@ set -q XDG_DATA_HOME
   or set -gx OMF_PATH "$HOME/.local/share/omf"
 
 # Load Oh My Fish configuration.
-source $OMF_PATH/init.fish
+test -f "$OMF_PATH/init.fish" && source "$OMF_PATH/init.fish"

--- a/chezmoi/private_dot_config/fish/conf.d/rustup.fish
+++ b/chezmoi/private_dot_config/fish/conf.d/rustup.fish
@@ -1,1 +1,1 @@
-source "$HOME/.cargo/env.fish"
+test -f "$HOME/.cargo/env.fish" && source "$HOME/.cargo/env.fish"

--- a/chezmoi/private_dot_config/fish/config.fish
+++ b/chezmoi/private_dot_config/fish/config.fish
@@ -2,7 +2,11 @@
   set --global fish_greeting
 
 # Homebrew
-  /opt/homebrew/bin/brew shellenv | source
+  if test -x /opt/homebrew/bin/brew
+    /opt/homebrew/bin/brew shellenv | source
+  else if test -x /home/linuxbrew/.linuxbrew/bin/brew
+    /home/linuxbrew/.linuxbrew/bin/brew shellenv | source
+  end
 
 # vars
   set --export PROJECTS_PATH $HOME/Projects/github.com
@@ -28,7 +32,7 @@
     --history=
 
 # Atuin
-  atuin init fish --disable-up-arrow | source
+  type -q atuin && atuin init fish --disable-up-arrow | source
 
 # EDITOR
   set --global --export EDITOR vim
@@ -50,17 +54,19 @@
 
 # gcloud cli tool
   set --global --export USE_GKE_GCLOUD_AUTH_PLUGIN "True"
-  source "$HOMEBREW_PREFIX/share/google-cloud-sdk/path.fish.inc"
+  test -f "$HOMEBREW_PREFIX/share/google-cloud-sdk/path.fish.inc" && source "$HOMEBREW_PREFIX/share/google-cloud-sdk/path.fish.inc"
 
 # install direnv hook (https://direnv.net/docs/hook.html#fish)
-  direnv hook fish | source
-  set --global direnv_fish_mode eval_on_arrow
+  if type -q direnv
+    direnv hook fish | source
+    set --global direnv_fish_mode eval_on_arrow
+  end
 
 # starship prompt
-  starship init fish | source
+  type -q starship && starship init fish | source
 
 # jump (https://github.com/gsamokovarov/jump)
-  jump shell fish | source
+  type -q jump && jump shell fish | source
 
 # locale
   set --global --export LC_ALL en_US.UTF-8


### PR DESCRIPTION
## Summary

Fix silent errors in Fish shell configuration by adding existence checks before sourcing files and running commands that may not be installed.

## Problem

CI test runs showed multiple errors when Fish config tried to source files or run commands that don't exist. These errors were silently failing (tests still passed), but cluttered test output and indicated fragile configuration.

Example errors:
- `source: Error encountered while sourcing file '/Users/runner/.local/share/omf/init.fish': No such file or directory`
- `source: Error encountered while sourcing file '/Users/runner/.cargo/env.fish': No such file or directory`
- `fish: Unknown command: atuin`
- `fish: Unknown command: direnv`
- `source: Error encountered while sourcing file '/opt/homebrew/share/google-cloud-sdk/path.fish.inc': No such file or directory`

## Changes

- `conf.d/omf.fish`: Added existence check before sourcing Oh My Fish `init.fish`
- `conf.d/rustup.fish`: Added existence check before sourcing Rust/Cargo environment
- `config.fish`: Added existence checks for Homebrew (both macOS `/opt/homebrew` and Linux `/home/linuxbrew` paths), Atuin shell history integration, Google Cloud SDK path, direnv environment loader, Starship prompt, and Jump directory navigator

## Benefits

- Eliminates error messages in CI when tools are not installed
- Makes Fish config more robust and portable
- Improves test output clarity
- Configuration gracefully handles missing optional dependencies

## Testing

- Local tests pass: `task test`
- Local linting passes: `task lint`
- Fish config loads without errors
- All 66 ShellSpec tests pass

> Changelog: skip