### PR TITLE
feat(repo): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for all files in the repository
+* @bartsmykla


### PR DESCRIPTION
## Summary

Add GitHub CODEOWNERS file to automatically assign bartsmykla as code owner and reviewer for all files in the repository.

## Changes

- Created `.github/CODEOWNERS` file
- Configured `* @bartsmykla` pattern to make bartsmykla the owner of all files

## Benefits

- GitHub automatically requests review from code owner when PRs are created
- Integrates with branch protection rules for code owner review requirements
- Provides clear ownership documentation for the repository
- Simplifies PR review assignment automation

## Testing

- File follows GitHub CODEOWNERS format
- Linting passes
- All tests pass

> Changelog: skip